### PR TITLE
[TA-4703]: RS256 jwt guard base contract

### DIFF
--- a/examples/jwt-rs256-guard/src/lib.rs
+++ b/examples/jwt-rs256-guard/src/lib.rs
@@ -155,7 +155,7 @@ impl JwtRS256Guard {
     /// Verifies custom claims in the JWT payload
     /// # Arguments
     /// * `jwt_payload` - Decoded JWT payload as bytes
-    /// * `sign_payload` - Payload to verify against the JWT fatxn claim
+    /// * `sign_payload` - Payload to be signed by the MPC
     /// # Returns
     /// * Tuple containing:
     ///   * Boolean indicating if verification succeeded
@@ -169,7 +169,7 @@ impl JwtRS256Guard {
 
         // NOTE: Verify your custom claim here
 
-        // Return the sub and fatxn fields
+        // Return the sub field
         (true, claims.sub)
     }
 
@@ -177,7 +177,7 @@ impl JwtRS256Guard {
     /// 
     /// # Arguments
     /// * `jwt` - The JWT token to verify as a string
-    /// * `sign_payload` - The payload to verify against the JWT fatxn claim
+    /// * `sign_payload` - The payload to be signed by the MPC
     /// 
     /// # Returns
     /// * Tuple containing:


### PR DESCRIPTION
# [TA-4703]: RS256 jwt guard base contract

## Changes :hammer_and_wrench:

### contracts/auth0-guard

- Refactored contract to separate concerns.
- New `jwt` and `rsa` crates

### examples/jwt-rs256-guard

- New template to build an JWT RS256 custom guard.