### PR TITLE
[TA-5258] fix(contracts): cross-contract privilage escalation fix

### DIFF
--- a/contracts/auth0-guard/src/lib.rs
+++ b/contracts/auth0-guard/src/lib.rs
@@ -78,7 +78,7 @@ impl Auth0Guard {
    /// # Panics
    /// Panics if the caller's account ID does not match the stored owner account ID
     fn only_owner(&self) {
-        assert!(env::signer_account_id() == self.owner, "Only the owner can call this function");
+        assert!(env::predecessor_account_id() == self.owner, "Only the owner can call this function");
     }
 
     /// Gets the current owner of the contract

--- a/contracts/fa/src/lib.rs
+++ b/contracts/fa/src/lib.rs
@@ -40,7 +40,7 @@ impl FastAuth {
     /// # Panics
     /// * If the caller is not the owner
     fn only_owner(&self) {
-        assert!(env::signer_account_id() == self.owner, "Only the owner can call this function");
+        assert!(env::predecessor_account_id() == self.owner, "Only the owner can call this function");
     }
 
     /// Gets the current owner of the contract

--- a/contracts/jwt-guard-router/src/lib.rs
+++ b/contracts/jwt-guard-router/src/lib.rs
@@ -54,7 +54,7 @@ impl JwtGuardRouter {
 
     /// Checks if caller is contract owner, panics if not
     fn only_owner(&self) {
-        assert_eq!(env::signer_account_id(), self.owner, "Only the owner can call this function");
+        assert_eq!(env::predecessor_account_id(), self.owner, "Only the owner can call this function");
     }
 
     /// Returns the account ID of contract owner

--- a/examples/jwt-rs256-guard/src/lib.rs
+++ b/examples/jwt-rs256-guard/src/lib.rs
@@ -80,7 +80,7 @@ impl JwtRS256Guard {
    /// # Panics
    /// Panics if the caller's account ID does not match the stored owner account ID
     fn only_owner(&self) {
-        assert!(env::signer_account_id() == self.owner, "Only the owner can call this function");
+        assert!(env::predecessor_account_id() == self.owner, "Only the owner can call this function");
     }
 
     /// Gets the current owner of the contract


### PR DESCRIPTION
# [TA-5258] fix(contracts): cross-contract privilage escalation fix

## Changes :hammer_and_wrench:

### contracts

-   Replaces the `signer_account_id` with `predecessor_account_id` for `only_owner` contract methods