### PR TITLE
[TA-5323][HAL-009] Excessive allocations parsing jwt with unbounded split

### DIFF
--- a/contracts/auth0-guard/src/jwt/codec.rs
+++ b/contracts/auth0-guard/src/jwt/codec.rs
@@ -2,16 +2,15 @@ use near_sdk::base64;
 use base64::Engine;
 
 pub fn decode_jwt(jwt: String) -> (String, String, String) {
-    // Split the JWT token into its parts
-    let parts: Vec<&str> = jwt.splitn(3, '.').collect();
-    if parts.len() != 3 {
+    let mut it = jwt.splitn(3, '.');
+    let (header, payload, signature) = match (it.next(), it.next(), it.next()) {
+        (Some(h), Some(p), Some(s)) => (h, p, s),
+        _ => return ("".to_string(), "".to_string(), "".to_string()),
+    };
+    // Reject tokens with extra dots
+    if signature.contains('.') {
         return ("".to_string(), "".to_string(), "".to_string());
     }
-
-    // Get the header and payload
-    let header = parts[0];
-    let payload = parts[1];
-    let signature = parts[2];
 
     (header.to_string(), payload.to_string(), signature.to_string())
 }


### PR DESCRIPTION
# [TA-5323][HAL-009] Excessive allocations parsing jwt with unbounded split

## Changes :hammer_and_wrench:

### contracts

- replace `split` with `splitn` on `decode_jwt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT decoding robustness to handle tokens with unexpected separators without failing early.
  * Preserves behavior for valid tokens while reducing spurious parsing errors in edge cases.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->