### PR TITLE
[TA-5452] add pausable capabilities

### DIFF
--- a/contracts/fa/src/lib.rs
+++ b/contracts/fa/src/lib.rs
@@ -123,7 +123,7 @@ impl FastAuth {
     /// * If the contract has already been initialized
     #[init]
     #[private]
-    pub fn init(init_guards: HashMap<String, AccountId>, owner: AccountId) -> Self {
+    pub fn init(init_guards: HashMap<String, AccountId>, owner: AccountId, pauser: AccountId) -> Self {
         if env::state_exists() {
             env::panic_str("Contract is already initialized");
         }
@@ -133,7 +133,7 @@ impl FastAuth {
             mpc_address: env::current_account_id(),
             mpc_key_version: DEFAULT_MPC_KEY_VERSION,
             version: CONTRACT_VERSION.to_string(),
-            pauser: env::current_account_id(),
+            pauser,
             paused: false,
         }
     }

--- a/contracts/fa/tests/test_integration.rs
+++ b/contracts/fa/tests/test_integration.rs
@@ -18,7 +18,7 @@ async fn test_guards_crud() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Test adding a guard with a forbidden character
-    let outcome = owner.call(contract.id(), "add_guard")
+    let _outcome = owner.call(contract.id(), "add_guard")
         .args_json(json!({
             "guard_id": "jwt#test",
             "guard_address": "jwt.fast-auth.near"
@@ -286,3 +286,387 @@ async fn test_mpc() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_pause() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test initial paused state
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, false);
+
+    // Test pausing the contract (should fail - only pauser can pause, not owner)
+    let pause_outcome = owner.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(!pause_outcome.is_success());
+
+    // Test unpausing the contract (should work - owner can unpause)
+    let unpause_outcome = owner.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(unpause_outcome.is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pauser_functionality() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let pauser = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test setting pauser (should work - owner can set pauser)
+    let set_pauser_outcome = owner.call(contract.id(), "set_pauser")
+        .args_json(json!({
+            "pauser": pauser.id()
+        }))
+        .transact()
+        .await?;
+    assert!(set_pauser_outcome.is_success());
+
+    // Test pausing with the new pauser (should work)
+    let pause_outcome = pauser.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(pause_outcome.is_success());
+
+    // Verify contract is paused
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, true);
+
+    // Test unpausing with owner (should work)
+    let unpause_outcome = owner.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(unpause_outcome.is_success());
+
+    // Verify contract is unpaused
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, false);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_paused_operations_blocked() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Pause the contract
+    let pause_outcome = contract
+        .call("pause")
+        .transact()
+        .await?;
+    assert!(pause_outcome.is_success());
+
+    // Test that operations are blocked when paused
+    // Test add_guard
+    let add_guard_outcome = owner.call(contract.id(), "add_guard")
+        .args_json(json!({
+            "guard_id": "jwt",
+            "guard_address": "jwt.fast-auth.near"
+        }))
+        .transact()
+        .await?;
+    assert!(!add_guard_outcome.is_success());
+
+    // Test remove_guard
+    let remove_guard_outcome = owner.call(contract.id(), "remove_guard")
+        .args_json(json!({
+            "guard_id": "jwt"
+        }))
+        .transact()
+        .await?;
+    assert!(!remove_guard_outcome.is_success());
+
+    // Test change_owner
+    let new_owner = sandbox.dev_create_account().await?;
+    let change_owner_outcome = owner.call(contract.id(), "change_owner")
+        .args_json(json!({
+            "new_owner": new_owner.id()
+        }))
+        .transact()
+        .await?;
+    assert!(!change_owner_outcome.is_success());
+
+    // Test set_mpc_address
+    let set_mpc_outcome = owner.call(contract.id(), "set_mpc_address")
+        .args_json(json!({
+            "mpc_address": "mpc.fast-auth.near"
+        }))
+        .transact()
+        .await?;
+    assert!(!set_mpc_outcome.is_success());
+
+    // Test set_mpc_key_version
+    let set_version_outcome = owner.call(contract.id(), "set_mpc_key_version")
+        .args_json(json!({
+            "mpc_key_version": 1
+        }))
+        .transact()
+        .await?;
+    assert!(!set_version_outcome.is_success());
+
+    // Test view functions that should still work when paused
+    // Test paused (should work - this is the only view function that works when paused)
+    let _paused_result = contract
+        .call("paused")
+        .view()
+        .await?;
+
+    // Test that owner() is blocked when paused (should panic)
+    let owner_result = contract
+        .call("owner")
+        .view()
+        .await;
+    assert!(owner_result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pause_unpause_authorization() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let pauser = sandbox.dev_create_account().await?;
+    let unauthorized_user = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Set pauser to a different account (owner can set pauser)
+    let set_pauser_outcome = owner.call(contract.id(), "set_pauser")
+        .args_json(json!({
+            "pauser": pauser.id()
+        }))
+        .transact()
+        .await?;
+    assert!(set_pauser_outcome.is_success());
+
+    // Test that owner cannot pause (only pauser can)
+    let owner_pause_outcome = owner.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(!owner_pause_outcome.is_success());
+
+    // Test that unauthorized user cannot pause
+    let unauthorized_pause_outcome = unauthorized_user.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(!unauthorized_pause_outcome.is_success());
+
+    // Test that pauser can pause
+    let pauser_pause_outcome = pauser.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(pauser_pause_outcome.is_success());
+
+    // Verify contract is paused
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, true);
+
+    // Test that pauser cannot unpause (only owner can)
+    let pauser_unpause_outcome = pauser.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(!pauser_unpause_outcome.is_success());
+
+    // Test that unauthorized user cannot unpause
+    let unauthorized_unpause_outcome = unauthorized_user.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(!unauthorized_unpause_outcome.is_success());
+
+    // Test that owner can unpause
+    let owner_unpause_outcome = owner.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(owner_unpause_outcome.is_success());
+
+    // Verify contract is unpaused
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, false);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_paused_state_management() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test initial paused state
+    let initial_paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(initial_paused_state, false);
+
+    // Pause the contract
+    let pause_outcome = contract
+        .call("pause")
+        .transact()
+        .await?;
+    assert!(pause_outcome.is_success());
+
+    // Test paused state after pausing
+    let paused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(paused_state, true);
+
+    // Unpause the contract
+    let unpause_outcome = owner.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(unpause_outcome.is_success());
+
+    // Test paused state after unpausing
+    let unpaused_state = contract
+        .call("paused")
+        .view()
+        .await?
+        .json::<bool>()?;
+    assert_eq!(unpaused_state, false);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_verify_and_sign_blocked_when_paused() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Deploy a mock guard contract
+    let mock_guard = sandbox.dev_deploy(include_bytes!("../../target/wasm32-unknown-unknown/release/external_guard.wasm")).await?;
+    
+    // Add the mock guard to the contract
+    let add_outcome = owner.call(contract.id(), "add_guard")
+        .args_json(json!({
+            "guard_id": "jwt",
+            "guard_address": mock_guard.id()
+        }))
+        .transact()
+        .await?;
+    assert!(add_outcome.is_success());
+
+    // Pause the contract
+    let pause_outcome = contract
+        .call("pause")
+        .transact()
+        .await?;
+    assert!(pause_outcome.is_success());
+
+    // Test that verify is blocked when paused
+    let verify_outcome = contract
+        .call("verify")
+        .args_json(json!({
+            "guard_id": "jwt#mock",
+            "verify_payload": "test_payload",
+            "sign_payload": vec![1, 2, 3]
+        }))
+        .transact()
+        .await?;
+    assert!(!verify_outcome.is_success());
+
+    // Test that sign is blocked when paused
+    let sign_outcome = contract
+        .call("sign")
+        .args_json(json!({
+            "guard_id": "jwt#mock",
+            "verify_payload": "test_payload",
+            "sign_payload": vec![1, 2, 3]
+        }))
+        .transact()
+        .await?;
+    assert!(!sign_outcome.is_success());
+
+    Ok(())
+}

--- a/contracts/fa/tests/test_integration.rs
+++ b/contracts/fa/tests/test_integration.rs
@@ -12,7 +12,8 @@ async fn test_guards_crud() -> Result<(), Box<dyn std::error::Error>> {
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -90,7 +91,8 @@ async fn test_owner() -> Result<(), Box<dyn std::error::Error>> {
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -297,7 +299,8 @@ async fn test_pause() -> Result<(), Box<dyn std::error::Error>> {
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -310,11 +313,11 @@ async fn test_pause() -> Result<(), Box<dyn std::error::Error>> {
         .json::<bool>()?;
     assert_eq!(paused_state, false);
 
-    // Test pausing the contract (should fail - only pauser can pause, not owner)
+    // Test pausing the contract (should work - owner is set as pauser)
     let pause_outcome = owner.call(contract.id(), "pause")
         .transact()
         .await?;
-    assert!(!pause_outcome.is_success());
+    assert!(pause_outcome.is_success());
 
     // Test unpausing the contract (should work - owner can unpause)
     let unpause_outcome = owner.call(contract.id(), "unpause")
@@ -337,7 +340,8 @@ async fn test_pauser_functionality() -> Result<(), Box<dyn std::error::Error>> {
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -393,14 +397,14 @@ async fn test_paused_operations_blocked() -> Result<(), Box<dyn std::error::Erro
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
 
-    // Pause the contract
-    let pause_outcome = contract
-        .call("pause")
+    // Pause the contract (owner is set as pauser)
+    let pause_outcome = owner.call(contract.id(), "pause")
         .transact()
         .await?;
     assert!(pause_outcome.is_success());
@@ -483,7 +487,8 @@ async fn test_pause_unpause_authorization() -> Result<(), Box<dyn std::error::Er
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -563,7 +568,8 @@ async fn test_paused_state_management() -> Result<(), Box<dyn std::error::Error>
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -576,9 +582,8 @@ async fn test_paused_state_management() -> Result<(), Box<dyn std::error::Error>
         .json::<bool>()?;
     assert_eq!(initial_paused_state, false);
 
-    // Pause the contract
-    let pause_outcome = contract
-        .call("pause")
+    // Pause the contract (owner is set as pauser)
+    let pause_outcome = owner.call(contract.id(), "pause")
         .transact()
         .await?;
     assert!(pause_outcome.is_success());
@@ -619,7 +624,8 @@ async fn test_verify_and_sign_blocked_when_paused() -> Result<(), Box<dyn std::e
     let _ = contract.call("init")
         .args_json(json!({
             "init_guards": {},
-            "owner": owner.id()
+            "owner": owner.id(),
+            "pauser": owner.id()
         }))
         .transact()
         .await?;
@@ -637,9 +643,8 @@ async fn test_verify_and_sign_blocked_when_paused() -> Result<(), Box<dyn std::e
         .await?;
     assert!(add_outcome.is_success());
 
-    // Pause the contract
-    let pause_outcome = contract
-        .call("pause")
+    // Pause the contract (owner is set as pauser)
+    let pause_outcome = owner.call(contract.id(), "pause")
         .transact()
         .await?;
     assert!(pause_outcome.is_success());


### PR DESCRIPTION
# [TA-5452] add pausable capabilities

## Changes :hammer_and_wrench:

### contracts/fa

- Added `pause`, `unpause` actions to manage pause state.
- Added `only_pauser` checker to whitelist pauser-only actions.
- Added `non_paused_only` checker to assert that the contract is not paused
- Added `paused` query.
- Added integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pausable mode with a dedicated pauser role; only the pauser can pause and the owner can unpause.
  * Ability to designate a pauser.
  * Most state-changing and sensitive operations are blocked while paused.
  * Public status check to see if the contract is paused; clearer feedback when actions are blocked.

* **Tests**
  * Expanded suite covering pause/unpause flows, pauser/owner authorization, and blocked operations while paused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->