### PR TITLE
[TA-5569]: add ecdsa signature support for fast auth contracts

### DIFF
--- a/contracts/fa/src/external_contracts.rs
+++ b/contracts/fa/src/external_contracts.rs
@@ -1,7 +1,8 @@
-use near_sdk::{ext_contract, PromiseOrValue};
+use near_sdk::{near, ext_contract, PromiseOrValue};
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
+use std::fmt::Debug;
 
 // Guard interface, for cross-contract calls
 #[ext_contract(external_guard)]
@@ -38,7 +39,30 @@ pub struct SignRequest {
     pub key_version: u32,
 }
 
+#[derive(Serialize, Deserialize, JsonSchema, BorshDeserialize, BorshSerialize)]
+#[serde(crate = "near_sdk::serde")]
+pub struct SignRequestV2 {
+    pub path: String,
+    // Either one of the following two must be present.
+    pub payload_v2: Vec<u8>,
+    // Either one of the following two must be present.
+    pub domain_id: u64,
+}
+
+/// A byte array with a statically encoded minimum and maximum length.
+/// The `new` function as well as json deserialization checks that the length is within bounds.
+/// The borsh deserialization does not perform such checks, as the borsh serialization is only
+/// used for internal contract storage.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[near(serializers=[borsh])]
+pub struct Bytes<const MIN_LEN: usize, const MAX_LEN: usize>(Vec<u8>);
+
+#[ext_contract(mpc_contract_legacy)]
+pub trait MPCContractLegacy {
+    fn sign(&self, request: SignRequest) -> PromiseOrValue<SignResponse>;
+}
+
 #[ext_contract(mpc_contract)]
 pub trait MPCContract {
-    fn sign(&self, request: SignRequest) -> PromiseOrValue<SignResponse>;
+    fn sign(&self, request: SignRequestV2) -> PromiseOrValue<SignResponse>;
 }

--- a/contracts/fa/src/lib.rs
+++ b/contracts/fa/src/lib.rs
@@ -551,6 +551,12 @@ mod tests {
         let contract = FastAuth { guards: HashMap::new(), owner: env::current_account_id(), mpc_address: env::current_account_id(), mpc_key_version: DEFAULT_MPC_KEY_VERSION, mpc_domain_id: DEFAULT_DOMAIN_ID, version: CONTRACT_VERSION.to_string(), paused: false, pauser: env::current_account_id() };
         assert_eq!(contract.mpc_key_version(), DEFAULT_MPC_KEY_VERSION);
     }
+
+    #[test]
+    fn mpc_domain_id() {
+        let contract = FastAuth { guards: HashMap::new(), owner: env::current_account_id(), mpc_address: env::current_account_id(), mpc_key_version: DEFAULT_MPC_KEY_VERSION, mpc_domain_id: DEFAULT_DOMAIN_ID, version: CONTRACT_VERSION.to_string(), paused: false, pauser: env::current_account_id() };
+        assert_eq!(contract.mpc_domain_id(), DEFAULT_DOMAIN_ID);
+    }
     
     #[test]
     fn version() {

--- a/contracts/fa/tests/test_integration.rs
+++ b/contracts/fa/tests/test_integration.rs
@@ -210,13 +210,14 @@ async fn test_sign() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     assert!(set_mpc_outcome.is_success());
 
-    // Call sign with a test payload
+    // Call sign with a test payload (using new version by default)
     let sign_outcome = contract
         .call("sign")
         .args_json(json!({
             "guard_id": "jwt#mock",
             "verify_payload": "test_payload",
-            "sign_payload": vec![1, 2, 3]
+            "sign_payload": vec![1, 2, 3],
+            "is_legacy": false
         }))
         .transact()
         .await?;
@@ -251,6 +252,13 @@ async fn test_mpc() -> Result<(), Box<dyn std::error::Error>> {
         .json::<u32>()?;
     assert_eq!(mpc_key_version, 0);
 
+    let mpc_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(mpc_domain_id, 0);
+
     // Test setting new MPC address
     let set_mpc_outcome = contract
         .call("set_mpc_address")
@@ -284,6 +292,23 @@ async fn test_mpc() -> Result<(), Box<dyn std::error::Error>> {
         .await?
         .json::<u32>()?;
     assert_eq!(new_key_version, 1);
+
+    // Test setting new domain ID
+    let set_domain_outcome = contract
+        .call("set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 42u64
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    let new_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(new_domain_id, 42);
 
     Ok(())
 }
@@ -456,6 +481,15 @@ async fn test_paused_operations_blocked() -> Result<(), Box<dyn std::error::Erro
         .transact()
         .await?;
     assert!(!set_version_outcome.is_success());
+
+    // Test set_mpc_domain_id
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 123u64
+        }))
+        .transact()
+        .await?;
+    assert!(!set_domain_outcome.is_success());
 
     // Test view functions that should still work when paused
     // Test paused (should work - this is the only view function that works when paused)
@@ -661,17 +695,484 @@ async fn test_verify_and_sign_blocked_when_paused() -> Result<(), Box<dyn std::e
         .await?;
     assert!(!verify_outcome.is_success());
 
-    // Test that sign is blocked when paused
+    // Test that sign is blocked when paused (new version)
     let sign_outcome = contract
         .call("sign")
         .args_json(json!({
             "guard_id": "jwt#mock",
             "verify_payload": "test_payload",
-            "sign_payload": vec![1, 2, 3]
+            "sign_payload": vec![1, 2, 3],
+            "is_legacy": false
         }))
         .transact()
         .await?;
     assert!(!sign_outcome.is_success());
+
+    // Test that sign is blocked when paused (legacy version)
+    let sign_legacy_outcome = contract
+        .call("sign")
+        .args_json(json!({
+            "guard_id": "jwt#mock",
+            "verify_payload": "test_payload",
+            "sign_payload": vec![1, 2, 3],
+            "is_legacy": true
+        }))
+        .transact()
+        .await?;
+    assert!(!sign_legacy_outcome.is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mpc_domain_id() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test initial domain ID value (should be 0)
+    let initial_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(initial_domain_id, 0);
+
+    // Test setting new domain ID
+    let new_domain_id = 12345u64;
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": new_domain_id
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    // Test getting the new domain ID
+    let updated_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(updated_domain_id, new_domain_id);
+
+    // Test setting domain ID to maximum u64 value
+    let max_domain_id = u64::MAX;
+    let set_max_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": max_domain_id
+        }))
+        .transact()
+        .await?;
+    assert!(set_max_domain_outcome.is_success());
+
+    let max_updated_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(max_updated_domain_id, max_domain_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mpc_domain_id_authorization() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let unauthorized_user = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test that unauthorized user cannot set domain ID
+    let unauthorized_set_outcome = unauthorized_user.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 999u64
+        }))
+        .transact()
+        .await?;
+    assert!(!unauthorized_set_outcome.is_success());
+
+    // Verify domain ID wasn't changed
+    let domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(domain_id, 0); // Should still be default value
+
+    // Test that owner can set domain ID
+    let owner_set_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 999u64
+        }))
+        .transact()
+        .await?;
+    assert!(owner_set_outcome.is_success());
+
+    // Verify domain ID was changed
+    let updated_domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(updated_domain_id, 999);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mpc_domain_id_blocked_when_paused() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Pause the contract
+    let pause_outcome = owner.call(contract.id(), "pause")
+        .transact()
+        .await?;
+    assert!(pause_outcome.is_success());
+
+    // Test that set_mpc_domain_id is blocked when paused
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 123u64
+        }))
+        .transact()
+        .await?;
+    assert!(!set_domain_outcome.is_success());
+
+    // Test that mpc_domain_id view is blocked when paused
+    let domain_id_result = contract
+        .call("mpc_domain_id")
+        .view()
+        .await;
+    assert!(domain_id_result.is_err());
+
+    // Unpause and verify operations work again
+    let unpause_outcome = owner.call(contract.id(), "unpause")
+        .transact()
+        .await?;
+    assert!(unpause_outcome.is_success());
+
+    // Now set_mpc_domain_id should work
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 123u64
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    // And mpc_domain_id view should work
+    let domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(domain_id, 123);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sign_legacy() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Deploy a mock guard contract
+    let mock_guard = sandbox.dev_deploy(include_bytes!("../../target/wasm32-unknown-unknown/release/external_guard.wasm")).await?;
+    
+    // Deploy a mock mpc contract
+    let mock_mpc = sandbox.dev_deploy(include_bytes!("../../target/wasm32-unknown-unknown/release/mpc.wasm")).await?;
+    
+    // Add the mock guard to the contract
+    let add_outcome = owner.call(contract.id(), "add_guard")
+        .args_json(json!({
+            "guard_id": "jwt",
+            "guard_address": mock_guard.id()
+        }))
+        .transact()
+        .await?;
+    assert!(add_outcome.is_success());
+
+    // Set the MPC address
+    let set_mpc_outcome = owner.call(contract.id(), "set_mpc_address")
+        .args_json(json!({
+            "mpc_address": mock_mpc.id()
+        }))
+        .transact()
+        .await?;
+    assert!(set_mpc_outcome.is_success());
+
+    // Set MPC key version for legacy compatibility
+    let set_version_outcome = owner.call(contract.id(), "set_mpc_key_version")
+        .args_json(json!({
+            "mpc_key_version": 1
+        }))
+        .transact()
+        .await?;
+    assert!(set_version_outcome.is_success());
+
+    // Call sign with legacy version (is_legacy: true)
+    let sign_outcome = contract
+        .call("sign")
+        .args_json(json!({
+            "guard_id": "jwt#mock",
+            "verify_payload": "test_payload",
+            "sign_payload": vec![1, 2, 3],
+            "is_legacy": true
+        }))
+        .transact()
+        .await?;
+
+    assert!(sign_outcome.is_success());
+
+    // Wait for the promise to complete and check the callback result
+    let result = sign_outcome.outcome();
+    assert!(result.is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sign() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Deploy a mock guard contract
+    let mock_guard = sandbox.dev_deploy(include_bytes!("../../target/wasm32-unknown-unknown/release/external_guard.wasm")).await?;
+    
+    // Deploy a mock mpc contract
+    let mock_mpc = sandbox.dev_deploy(include_bytes!("../../target/wasm32-unknown-unknown/release/mpc.wasm")).await?;
+    
+    // Add the mock guard to the contract
+    let add_outcome = owner.call(contract.id(), "add_guard")
+        .args_json(json!({
+            "guard_id": "jwt",
+            "guard_address": mock_guard.id()
+        }))
+        .transact()
+        .await?;
+    assert!(add_outcome.is_success());
+
+    // Set the MPC address
+    let set_mpc_outcome = owner.call(contract.id(), "set_mpc_address")
+        .args_json(json!({
+            "mpc_address": mock_mpc.id()
+        }))
+        .transact()
+        .await?;
+    assert!(set_mpc_outcome.is_success());
+
+    // Set MPC domain ID for new version
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 42u64
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    // Call sign with new version (is_legacy: false)
+    let sign_outcome = contract
+        .call("sign")
+        .args_json(json!({
+            "guard_id": "jwt#mock",
+            "verify_payload": "test_payload",
+            "sign_payload": vec![1, 2, 3],
+            "is_legacy": false
+        }))
+        .transact()
+        .await?;
+
+    assert!(sign_outcome.is_success());
+
+    // Wait for the promise to complete and check the callback result
+    let result = sign_outcome.outcome();
+    assert!(result.is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sign_legacy_vs_new_version_parameters() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Set different values for key_version and domain_id to test they're used correctly
+    let set_version_outcome = owner.call(contract.id(), "set_mpc_key_version")
+        .args_json(json!({
+            "mpc_key_version": 5
+        }))
+        .transact()
+        .await?;
+    assert!(set_version_outcome.is_success());
+
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": 999u64
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    // Verify the values are set correctly
+    let key_version = contract
+        .call("mpc_key_version")
+        .view()
+        .await?
+        .json::<u32>()?;
+    assert_eq!(key_version, 5);
+
+    let domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(domain_id, 999);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mpc_configuration_complete() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_wasm = near_workspaces::compile_project("./").await?;
+    let sandbox = near_workspaces::sandbox().await?;
+    let owner = sandbox.dev_create_account().await?;
+    let contract = sandbox.dev_deploy(&contract_wasm).await?;
+
+    // Initialize contract with owner
+    let _ = contract.call("init")
+        .args_json(json!({
+            "init_guards": {},
+            "owner": owner.id(),
+            "pauser": owner.id()
+        }))
+        .transact()
+        .await?;
+
+    // Test all MPC-related parameters together
+    let new_mpc_address = "mpc.fast-auth.near";
+    let new_key_version = 42u32;
+    let new_domain_id = 1337u64;
+
+    // Set MPC address
+    let set_mpc_outcome = owner.call(contract.id(), "set_mpc_address")
+        .args_json(json!({
+            "mpc_address": new_mpc_address
+        }))
+        .transact()
+        .await?;
+    assert!(set_mpc_outcome.is_success());
+
+    // Set MPC key version
+    let set_version_outcome = owner.call(contract.id(), "set_mpc_key_version")
+        .args_json(json!({
+            "mpc_key_version": new_key_version
+        }))
+        .transact()
+        .await?;
+    assert!(set_version_outcome.is_success());
+
+    // Set MPC domain ID
+    let set_domain_outcome = owner.call(contract.id(), "set_mpc_domain_id")
+        .args_json(json!({
+            "mpc_domain_id": new_domain_id
+        }))
+        .transact()
+        .await?;
+    assert!(set_domain_outcome.is_success());
+
+    // Verify all values are set correctly
+    let mpc_address = contract
+        .call("mpc_address")
+        .view()
+        .await?
+        .json::<near_sdk::AccountId>()?;
+    assert_eq!(mpc_address, new_mpc_address);
+
+    let key_version = contract
+        .call("mpc_key_version")
+        .view()
+        .await?
+        .json::<u32>()?;
+    assert_eq!(key_version, new_key_version);
+
+    let domain_id = contract
+        .call("mpc_domain_id")
+        .view()
+        .await?
+        .json::<u64>()?;
+    assert_eq!(domain_id, new_domain_id);
 
     Ok(())
 }

--- a/contracts/fa/tests/test_integration.rs
+++ b/contracts/fa/tests/test_integration.rs
@@ -980,7 +980,7 @@ async fn test_sign_legacy() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-async fn test_sign() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_sign_v2() -> Result<(), Box<dyn std::error::Error>> {
     let contract_wasm = near_workspaces::compile_project("./").await?;
     let sandbox = near_workspaces::sandbox().await?;
     let owner = sandbox.dev_create_account().await?;

--- a/contracts/rust-toolchain.toml
+++ b/contracts/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.86.0"
 components = ["rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/contracts/rust-toolchain.toml
+++ b/contracts/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "stable"
 components = ["rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# [TA-5569]: add ecdsa signature support for fast auth contracts

## Changes :hammer_and_wrench:

### contracts/fa

- Updated `sign` method with `is_legacy` parameter.
- Handled support for MPC V2 `ecdsa` request signatures