### PR TITLE
feat(custom-issuer): add health endpoints and Prometheus metrics

### DIFF
--- a/apps/custom-issuer/package.json
+++ b/apps/custom-issuer/package.json
@@ -20,10 +20,12 @@
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@willsoto/nestjs-prometheus": "^6.0.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.0",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.2",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/apps/custom-issuer/src/app.module.ts
+++ b/apps/custom-issuer/src/app.module.ts
@@ -22,7 +22,7 @@ import { HttpExceptionFilter } from "./common/filters/http-exception.filter";
                 return {
                     defaultLabels: {
                         app: config.get("prometheus.appName"),
-                        environment: process.env.CONFIG_ENV || process.env.NODE_ENV || "development",
+                        environment: config.get("prometheus.env"),
                     },
                 };
             },

--- a/apps/custom-issuer/src/app.module.ts
+++ b/apps/custom-issuer/src/app.module.ts
@@ -1,7 +1,9 @@
 import { Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
+import { ConfigModule, ConfigService } from "@nestjs/config";
 import { APP_FILTER } from "@nestjs/core";
+import { PrometheusModule } from "@willsoto/nestjs-prometheus";
 import { IssuerModule } from "./modules/issuer/issuer.module";
+import { HealthModule } from "./modules/health/health.module";
 import configuration from "./config";
 import { HttpExceptionFilter } from "./common/filters/http-exception.filter";
 
@@ -12,7 +14,21 @@ import { HttpExceptionFilter } from "./common/filters/http-exception.filter";
             isGlobal: true,
             envFilePath: [".env"],
         }),
+        PrometheusModule.registerAsync({
+            inject: [ConfigService],
+            imports: [ConfigModule],
+            useFactory: async (config: ConfigService) => {
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+                return {
+                    defaultLabels: {
+                        app: config.get("prometheus.appName"),
+                        environment: process.env.CONFIG_ENV || process.env.NODE_ENV || "development",
+                    },
+                };
+            },
+        }),
         IssuerModule,
+        HealthModule,
     ],
     providers: [
         {

--- a/apps/custom-issuer/src/config/index.ts
+++ b/apps/custom-issuer/src/config/index.ts
@@ -1,11 +1,14 @@
 import issuerConfig, { IssuerConfig } from "./issuer.config";
+import prometheusConfig, { PrometheusConfig } from "./prometheus.config";
 
 export type Config = {
     issuer: IssuerConfig;
+    prometheus: PrometheusConfig;
 };
 
 export default (): Config => {
     return {
         issuer: issuerConfig(),
+        prometheus: prometheusConfig(),
     };
 };

--- a/apps/custom-issuer/src/config/prometheus.config.ts
+++ b/apps/custom-issuer/src/config/prometheus.config.ts
@@ -1,0 +1,13 @@
+export interface PrometheusConfig {
+    appName: string;
+}
+
+/**
+ * Builds the Prometheus configuration.
+ * @returns The Prometheus configuration.
+ */
+export default (): PrometheusConfig => {
+    return {
+        appName: process.env.APP_NAME || "custom-issuer",
+    };
+};

--- a/apps/custom-issuer/src/config/prometheus.config.ts
+++ b/apps/custom-issuer/src/config/prometheus.config.ts
@@ -1,5 +1,6 @@
 export interface PrometheusConfig {
     appName: string;
+    env: string;
 }
 
 /**
@@ -9,5 +10,6 @@ export interface PrometheusConfig {
 export default (): PrometheusConfig => {
     return {
         appName: process.env.APP_NAME || "custom-issuer",
+        env: process.env.CONFIG_ENV || process.env.NODE_ENV || "development",
     };
 };

--- a/apps/custom-issuer/src/modules/common/metric/metric.ts
+++ b/apps/custom-issuer/src/modules/common/metric/metric.ts
@@ -1,0 +1,39 @@
+import { makeCounterProvider, makeGaugeProvider, makeHistogramProvider } from "@willsoto/nestjs-prometheus";
+import { Provider } from "@nestjs/common";
+
+export type MetricType = "counter" | "gauge" | "histogram";
+export type ModuleMetric = { type: MetricType; help: string };
+export type ModuleMetrics = Record<string, ModuleMetric>;
+
+/**
+ * Compose DI providers for the given metrics plus a base provider.
+ * @param provider The base provider.
+ * @param metrics The set of metrics.
+ * @returns All the composed providers.
+ */
+export const createMetricsProvider = (provider: Provider, metrics: ModuleMetrics): Provider[] => {
+    return [
+        provider,
+        ...Object.keys(metrics).map((name: string): Provider => {
+            switch (metrics[name].type) {
+                case "counter":
+                    return makeCounterProvider({
+                        name: name,
+                        help: metrics[name].help,
+                    });
+                case "gauge":
+                    return makeGaugeProvider({
+                        name: name,
+                        help: metrics[name].help,
+                    });
+                case "histogram":
+                    return makeHistogramProvider({
+                        name: name,
+                        help: metrics[name].help,
+                    });
+                default:
+                    throw new Error("Unknown metric type");
+            }
+        }),
+    ];
+};

--- a/apps/custom-issuer/src/modules/health/dtos/readyz.dto.ts
+++ b/apps/custom-issuer/src/modules/health/dtos/readyz.dto.ts
@@ -1,0 +1,18 @@
+import { HealthCheckStatus, HealthDependencyCheckerResult } from "../types/health-check";
+
+export class ReadyzResponseDto {
+    status: HealthCheckStatus;
+    checks: Record<string, HealthDependencyCheckerResult>;
+
+    /**
+     * Converts checkers to a ReadyzResponseDto.
+     * @param checkers The checkers to convert.
+     * @returns The ReadyzResponseDto.
+     */
+    static fromDependencyCheckers(checkers: Record<string, HealthDependencyCheckerResult>): ReadyzResponseDto {
+        return {
+            status: Object.values(checkers).every((checker) => checker.status === "ok") ? "ok" : "error",
+            checks: checkers,
+        };
+    }
+}

--- a/apps/custom-issuer/src/modules/health/health.controller.ts
+++ b/apps/custom-issuer/src/modules/health/health.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, HttpStatus, Res } from "@nestjs/common";
+import type { Response } from "express";
+import { HealthService } from "./health.service";
+
+@Controller()
+export class HealthController {
+    constructor(private readonly healthService: HealthService) {}
+
+    /**
+     * Liveness probe endpoint.
+     * @param res The response.
+     * @returns If success 200 OK to indicate the application is running.
+     */
+    @Get("livez")
+    livez(@Res() res: Response) {
+        return res.status(HttpStatus.OK).json();
+    }
+
+    /**
+     * Readiness probe endpoint.
+     * Checks validation keys health before returning success.
+     * @param res The response.
+     * @returns If success 200 OK to indicate the application is running.
+     */
+    @Get("readyz")
+    async readyz(@Res() res: Response) {
+        const healthCheck = await this.healthService.checkHealth();
+
+        if (healthCheck.status === "ok") {
+            return res.status(HttpStatus.OK).json(healthCheck);
+        } else {
+            return res.status(HttpStatus.SERVICE_UNAVAILABLE).json(healthCheck);
+        }
+    }
+}

--- a/apps/custom-issuer/src/modules/health/health.module.ts
+++ b/apps/custom-issuer/src/modules/health/health.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller";
+import { HealthService } from "./health.service";
+import { IssuerModule } from "../issuer/issuer.module";
+
+@Module({
+    imports: [IssuerModule],
+    controllers: [HealthController],
+    providers: [HealthService],
+})
+export class HealthModule {}

--- a/apps/custom-issuer/src/modules/health/health.service.ts
+++ b/apps/custom-issuer/src/modules/health/health.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ReadyzResponseDto } from "./dtos/readyz.dto";
+import { HealthDependencyCheckerResult } from "./types/health-check";
+import { KeyService } from "../issuer/key.service";
+
+@Injectable()
+export class HealthService {
+    private readonly logger = new Logger(HealthService.name);
+
+    constructor(private readonly keyService: KeyService) {}
+
+    async checkHealth(): Promise<ReadyzResponseDto> {
+        return ReadyzResponseDto.fromDependencyCheckers({
+            "validation-keys": await this.checkValidationKeys(),
+        });
+    }
+
+    private async checkValidationKeys(): Promise<HealthDependencyCheckerResult> {
+        try {
+            // Throws if no keys are loaded
+            this.keyService.getValidationPublicKeys();
+            return { status: "ok" };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            this.logger.error(`Validation keys health check failed: ${errorMessage}`);
+            return { status: "error", message: errorMessage };
+        }
+    }
+}

--- a/apps/custom-issuer/src/modules/health/health.service.ts
+++ b/apps/custom-issuer/src/modules/health/health.service.ts
@@ -15,7 +15,7 @@ export class HealthService {
         });
     }
 
-    private async checkValidationKeys(): Promise<HealthDependencyCheckerResult> {
+    private checkValidationKeys(): HealthDependencyCheckerResult {
         try {
             // Throws if no keys are loaded
             this.keyService.getValidationPublicKeys();

--- a/apps/custom-issuer/src/modules/health/types/health-check.ts
+++ b/apps/custom-issuer/src/modules/health/types/health-check.ts
@@ -1,0 +1,6 @@
+export type HealthCheckStatus = "ok" | "error";
+
+export interface HealthDependencyCheckerResult {
+    status: HealthCheckStatus;
+    message?: string;
+}

--- a/apps/custom-issuer/src/modules/issuer/issuer.constants.ts
+++ b/apps/custom-issuer/src/modules/issuer/issuer.constants.ts
@@ -1,2 +1,3 @@
 export const JWT_ALGORITHM = "RS256" as const;
 export const SECONDS_IN_MILLISECOND = 1000;
+export const NS_PER_SECOND = 1e9;

--- a/apps/custom-issuer/src/modules/issuer/issuer.metrics.ts
+++ b/apps/custom-issuer/src/modules/issuer/issuer.metrics.ts
@@ -1,0 +1,46 @@
+import { ModuleMetrics } from "../common/metric/metric";
+import { Injectable } from "@nestjs/common";
+import { InjectMetric } from "@willsoto/nestjs-prometheus";
+import { Counter, Histogram } from "prom-client";
+
+export enum IssuerMetric {
+    TOKENS_ISSUED_TOTAL = "custom_issuer_tokens_issued_total",
+    TOKENS_FAILED_TOTAL = "custom_issuer_tokens_failed_total",
+    ISSUE_DURATION_SECONDS = "custom_issuer_issue_duration_seconds",
+}
+
+export const IssuerMetrics: ModuleMetrics = {
+    [IssuerMetric.TOKENS_ISSUED_TOTAL]: {
+        type: "counter",
+        help: "Total number of successfully issued tokens",
+    },
+    [IssuerMetric.TOKENS_FAILED_TOTAL]: {
+        type: "counter",
+        help: "Total number of failed token issuance attempts",
+    },
+    [IssuerMetric.ISSUE_DURATION_SECONDS]: {
+        type: "histogram",
+        help: "Duration of token issuance in seconds",
+    },
+};
+
+@Injectable()
+export class IssuerMetricsProvider {
+    constructor(
+        @InjectMetric(IssuerMetric.TOKENS_ISSUED_TOTAL) private readonly issuedMetric: Counter<string>,
+        @InjectMetric(IssuerMetric.TOKENS_FAILED_TOTAL) private readonly failedMetric: Counter<string>,
+        @InjectMetric(IssuerMetric.ISSUE_DURATION_SECONDS) private readonly durationMetric: Histogram<string>,
+    ) {}
+
+    incrementIssued(count = 1) {
+        this.issuedMetric.inc(count);
+    }
+
+    incrementFailed(count = 1) {
+        this.failedMetric.inc(count);
+    }
+
+    observeDuration(seconds: number) {
+        this.durationMetric.observe(seconds);
+    }
+}

--- a/apps/custom-issuer/src/modules/issuer/issuer.module.ts
+++ b/apps/custom-issuer/src/modules/issuer/issuer.module.ts
@@ -2,9 +2,12 @@ import { Module } from "@nestjs/common";
 import { IssuerService } from "./issuer.service";
 import { IssuerController } from "./issuer.controller";
 import { KeyService } from "./key.service";
+import { createMetricsProvider } from "../common/metric/metric";
+import { IssuerMetricsProvider, IssuerMetrics } from "./issuer.metrics";
 
 @Module({
-    providers: [IssuerService, KeyService],
+    providers: [IssuerService, KeyService, ...createMetricsProvider(IssuerMetricsProvider, IssuerMetrics)],
     controllers: [IssuerController],
+    exports: [KeyService],
 })
 export class IssuerModule {}

--- a/apps/custom-issuer/src/modules/issuer/issuer.service.ts
+++ b/apps/custom-issuer/src/modules/issuer/issuer.service.ts
@@ -2,10 +2,11 @@ import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import * as jwt from "jsonwebtoken";
 import { KeyService } from "./key.service";
-import { JWT_ALGORITHM, SECONDS_IN_MILLISECOND } from "./issuer.constants";
+import { JWT_ALGORITHM, NS_PER_SECOND, SECONDS_IN_MILLISECOND } from "./issuer.constants";
 import { ErrorMessage } from "./issuer.errors";
 import { TokenClaims } from "./issuer.types";
 import { Config } from "../../config";
+import { IssuerMetricsProvider } from "./issuer.metrics";
 
 @Injectable()
 export class IssuerService {
@@ -16,6 +17,7 @@ export class IssuerService {
     constructor(
         private readonly keyService: KeyService,
         private readonly configService: ConfigService<Config>,
+        private readonly metrics: IssuerMetricsProvider,
     ) {
         // Get issuer configuration from typed configuration
         const issuerConfig = this.configService.get<Config["issuer"]>("issuer");
@@ -38,9 +40,20 @@ export class IssuerService {
     }
 
     async issueToken(inputJwt: string, signPayload: number[]): Promise<string> {
-        const decoded = this.verifyAndDecodeToken(inputJwt);
-        const claims = this.extractAndValidateClaims(decoded, signPayload);
-        return this.createSignedToken(claims);
+        const start = process.hrtime.bigint();
+        try {
+            const decoded = this.verifyAndDecodeToken(inputJwt);
+            const claims = this.extractAndValidateClaims(decoded, signPayload);
+            const token = this.createSignedToken(claims);
+            this.metrics.incrementIssued();
+            return token;
+        } catch (error) {
+            this.metrics.incrementFailed();
+            throw error;
+        } finally {
+            const durationNs = process.hrtime.bigint() - start;
+            this.metrics.observeDuration(Number(durationNs) / NS_PER_SECOND);
+        }
     }
 
     private verifyAndDecodeToken(inputJwt: string): jwt.JwtPayload {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)
+      '@willsoto/nestjs-prometheus':
+        specifier: ^6.0.2
+        version: 6.0.2(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -120,6 +123,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -406,6 +412,8 @@ importers:
   contracts/jwt-guards/auth0-guard: {}
 
   contracts/jwt-guards/base-jwt-guard: {}
+
+  contracts/jwt-guards/custom-issuer-guard: {}
 
   contracts/jwt-guards/firebase-guard: {}
 
@@ -19517,6 +19525,11 @@ snapshots:
   '@willsoto/nestjs-prometheus@6.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.2))(prom-client@15.1.3)':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.2)
+      prom-client: 15.1.3
+
+  '@willsoto/nestjs-prometheus@6.0.2(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)':
+    dependencies:
+      '@nestjs/common': 11.1.11(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       prom-client: 15.1.3
 
   '@xtuc/ieee754@1.2.0': {}


### PR DESCRIPTION
# feat(custom-issuer): add health endpoints and Prometheus metrics

## Changes :hammer_and_wrench:

### app/custom-issuer

  - Added health endpoints:
    - `/livez` -> liveness probe, always returns 200 OK
    - `/readyz` -> readiness probe, checks validation keys are loaded; returns 200 OK or 503 Service Unavailable
  - Added Prometheus metrics integration
    - Exposed `/metrics` endpoint serving all Prometheus-formatted metrics for scraping
    - `custom_issuer_tokens_issued_total` (counter) -> total successfully issued tokens
    - `custom_issuer_tokens_failed_total` (counter) -> total failed token issuance attempts
    - `custom_issuer_issue_duration_seconds` (histogram) -> token issuance duration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added liveness and readiness endpoints (/livez, /readyz) with status-dependent HTTP codes.
  * Integrated Prometheus metrics and configuration for observability.
  * Enabled metrics for token issuance: success count, failure count, and issuance duration.
  * Readiness now reports dependency checks (e.g., validation keys) in its response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->