### PR TITLE
fix(custom-issuer-go): expose app and environment as prometheus metric labels

### DIFF
--- a/apps/custom-issuer-go/config/config.go
+++ b/apps/custom-issuer-go/config/config.go
@@ -11,6 +11,8 @@ import (
 )
 
 type Config struct {
+	AppName                string
+	Environment            string
 	Port                   int
 	ValidationPublicKeyURL string
 	ValidationIssuerURL    string
@@ -65,7 +67,10 @@ func LoadEnv(path string) {
 }
 
 func Load() (*Config, error) {
-	cfg := &Config{}
+	cfg := &Config{
+		AppName:     parseStringEnv("APP_NAME", "custom-issuer-go"),
+		Environment: parseStringEnv("CONFIG_ENV", "development"),
+	}
 	var err error
 
 	if cfg.Port, err = parsePort(); err != nil {
@@ -148,6 +153,14 @@ func parseRequiredEnv(name string) (string, error) {
 		return "", fmt.Errorf("missing required environment variable: %s", name)
 	}
 	return val, nil
+}
+
+func parseStringEnv(name string, fallback string) string {
+	val := strings.TrimSpace(os.Getenv(name))
+	if val == "" {
+		return fallback
+	}
+	return val
 }
 
 func parseHTTPURL(name string) (string, error) {

--- a/apps/custom-issuer-go/modules/metrics/module.go
+++ b/apps/custom-issuer-go/modules/metrics/module.go
@@ -31,15 +31,19 @@ type Module struct {
 }
 
 // Init initializes the OTel MeterProvider with a Prometheus exporter.
-func (m *Module) Init(_ *config.Config, _ *modules.AppModules) error {
-	exporter, err := prometheus.New()
+func (m *Module) Init(cfg *config.Config, _ *modules.AppModules) error {
+	exporter, err := prometheus.New(
+		prometheus.WithResourceAsConstantLabels(attribute.NewAllowKeysFilter("app", "environment", "service.name")),
+	)
 	if err != nil {
 		return err
 	}
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewSchemaless(
-			attribute.String("service.name", "custom-issuer-go"),
+			attribute.String("app", cfg.AppName),
+			attribute.String("environment", cfg.Environment),
+			attribute.String("service.name", cfg.AppName),
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
# fix(custom-issuer-go): expose app and environment as prometheus metric labels

## Changes :hammer_and_wrench:

### custom-issuer-go

  -   Add `AppName` and `Environment` fields to `Config`, loaded from `APP_NAME` (default `custom-issuer-go`) and `CONFIG_ENV` (default `development`) env vars.
  -   Promote `app`, `environment`, and `service.name` OTel resource attributes to constant labels on every Prometheus metric, so Grafana dashboards can filter by `app=` / `environment=`.
  -   Use `cfg.AppName` for `service.name` instead of the hardcoded `"custom-issuer-go"` string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now supports configurable app name and environment settings via environment variables, with sensible defaults.
  * Metrics now include proper labels for app name and environment, enabling improved observability and filtering capabilities across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->