### PR TITLE
fix(sdk): export @shared/core types so examples/spa (fast-auth-spa) builds

### DIFF
--- a/examples/spa/vercel.json
+++ b/examples/spa/vercel.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+    "buildCommand": "cd ../.. && npx turbo run build --filter=spa",
+    "outputDirectory": "dist"
+}

--- a/packages/shared/core/src/index.ts
+++ b/packages/shared/core/src/index.ts
@@ -19,4 +19,13 @@ export const FAST_AUTH_AUTH0_DEFAULTS: Record<FastAuthNetwork, FastAuthAuth0Netw
     },
 } as const;
 
-export * from "./provider";
+export type {
+    User,
+    LoginResponse,
+    RequestTransactionSignatureResponse,
+    RequestDelegateActionSignatureResponse,
+    GetSignatureRequestResponse,
+    IFastAuthProvider,
+    MPCContractAlgorithm,
+    SignatureRequest,
+} from "./provider";


### PR DESCRIPTION
## Summary

Fixes the failing **`fast-auth-spa`** (`examples/spa`) build. Two layers, both addressed here.

## Layer 2 — the real bug (code, verified)

`browser-sdk` (and the providers) re-export `@shared/core` via `export * from "@shared/core"`. During tsup's DTS bundling, `@shared/core`'s own `export * from "./provider"` became a **dangling `./provider` reference** in the generated `dist/index.d.ts` — the `provider.d.ts` chunk is never emitted. As a result the re-exported `@shared/core` types (`SignatureRequest`, `IFastAuthProvider`, `User`, `GetSignatureRequestResponse`, …) were *imported-but-not-exported*. `examples/spa` imports `SignatureRequest` from `@fast-auth-near/browser-sdk` and failed:

```
TS2459: Module '@fast-auth-near/browser-sdk' declares 'SignatureRequest' locally, but it is not exported.
```

**Fix:** replace the wildcard in `packages/shared/core/src/index.ts` with **explicit named re-exports** of `./provider`. Explicit names land on the public export list, so every consumer re-exports them correctly.

## Layer 1 — Vercel wasn't building the workspace packages (config)

Vercel's `pnpm install` links the workspace SDKs but doesn't **build** them, so `tsc -b` couldn't find their types (the original `TS2307`). Added `examples/spa/vercel.json` so the deploy installs + builds from the repo root via turbo (which builds deps in dependency order).

## Verification

- ✅ `npx turbo run build --filter=spa` — **green** (`tsc -b` + `vite build` succeed)
- ✅ `pnpm build:packages` — 14/14 build
- ✅ `turbo run check-types` (packages) — 8/8 pass
- ⚠️ The `vercel.json` (Layer 1) I **could not verify on Vercel** — the CLI is only authenticated for an account that can't see the `fast-auth-spa` deployment. Please confirm on a redeploy with the owning account; if that project's **Root Directory** isn't `examples/spa`, the relative `cd ../..` paths need adjusting.

## Scope

Independent of the landing rebrand (#100). Touches only `packages/shared/core` + `examples/spa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
