### PR TITLE
fix(javascript-provider): request the API audience on login

### DIFF
--- a/packages/providers/javascript/src/provider.ts
+++ b/packages/providers/javascript/src/provider.ts
@@ -42,7 +42,12 @@ export class JavascriptProvider implements IFastAuthProvider {
         this.client = new Auth0Client({
             domain: this.options.domain,
             clientId: this.options.clientId,
-            authorizationParams: {},
+            // Default to the network's API audience so a plain login requests it
+            // explicitly. Without it, Auth0 falls back to the tenant's Default Audience
+            // (the on-chain signing audience), which the post-login Action rejects for a
+            // login that carries no transaction payload. Signature requests override this
+            // with `signingAudience`.
+            authorizationParams: { audience: defaults.audience },
         });
     }
 

--- a/packages/providers/javascript/test/provider.spec.ts
+++ b/packages/providers/javascript/test/provider.spec.ts
@@ -65,6 +65,17 @@ describe("JavascriptProvider", () => {
         provider = new JavascriptProvider(mockOptions);
     });
 
+    describe("constructor", () => {
+        it("configures the network's API audience so a plain login does not inherit the tenant signing audience", () => {
+            const { Auth0Client } = jest.requireMock("@auth0/auth0-spa-js");
+            expect(Auth0Client).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authorizationParams: { audience: "https://api.testnet.fast-auth.com" },
+                }),
+            );
+        });
+    });
+
     describe("isLoggedIn", () => {
         beforeEach(() => {
             mockLocation.search = "";


### PR DESCRIPTION
## Problem
`JavascriptProvider` login can never succeed against a tenant whose **Default Audience is the on-chain signing audience** (which mainnet is).

The constructor computes `defaults.audience` (the network's API audience) but **never uses it** — the Auth0Client is built with an empty `authorizationParams`:

```ts
const defaults = FAST_AUTH_AUTH0_DEFAULTS[options.network]; // .audience = https://api.auth.near.org
...
this.client = new Auth0Client({
    domain, clientId,
    authorizationParams: {},   // ← API audience dropped
});
```

So a plain `login()` sends **no audience** → Auth0 applies the tenant Default Audience (`auth0.jwt.fast-auth.near`, the signing audience) → the post-login `authorize-app` Action denies it:

```
error=access_denied
error_description=Signing audience requested without transaction payload
```

(`authorize-app.action.js`: `isOnchainAudience && !hasSigningPayload → deny(...)`; a login carries no transaction payload.)

## Fix
```diff
- authorizationParams: {},
+ authorizationParams: { audience: defaults.audience },
```
Login now requests the API audience (`https://api.auth.near.org`) → `event.resource_server.identifier !== ONCHAIN_AUDIENCE` → the Action's `if (!isOnchainAudience) return` **allows** it. Signature requests are unaffected — `requestTransactionSignature` / `getSignatureRequest` override `audience` with `signingAudience` and send a transaction payload.

## Verified
- `pnpm test` in `packages/providers/javascript`: **45/45 pass** (added a regression test asserting the constructor passes the network's API audience).
- Reproduced end-to-end on a mainnet app (neartrader4, SDK 1.4.1): the redirect returned exactly `?error=access_denied&error_description=Signing%20audience%20requested%20without%20transaction%20payload`. This fix makes login request the API audience instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)