### PR TITLE
fix: use finality final instead of sync_checkpoint in rpc view calls

### DIFF
--- a/apps/relayer/src/modules/near/near-client.service.ts
+++ b/apps/relayer/src/modules/near/near-client.service.ts
@@ -91,7 +91,7 @@ export class NearClientService {
             account_id: accountId,
             method_name: method,
             args_base64: encodedArgs.toString("base64"),
-            sync_checkpoint: "earliest_available",
+            finality: "final",
         });
         return JSON.parse(Buffer.from(result.result).toString());
     }

--- a/packages/sdks/browser/src/signers/signer.ts
+++ b/packages/sdks/browser/src/signers/signer.ts
@@ -52,7 +52,7 @@ export class FastAuthSigner<P extends IFastAuthProvider = IFastAuthProvider> {
             account_id: contractId,
             method_name: methodName,
             args_base64: encodedArgs.toString("base64"),
-            sync_checkpoint: "earliest_available",
+            finality: "final",
         });
 
         return JSON.parse(Buffer.from(result.result).toString());

--- a/packages/sdks/browser/test/signers/signer.spec.ts
+++ b/packages/sdks/browser/test/signers/signer.spec.ts
@@ -77,6 +77,7 @@ describe("FastAuthSigner", () => {
                     request_type: "call_function",
                     account_id: options.mpcContractId,
                     method_name: "derived_public_key",
+                    finality: "final",
                 }),
             );
 

--- a/packages/sdks/react/src/core/signers/signer.ts
+++ b/packages/sdks/react/src/core/signers/signer.ts
@@ -65,7 +65,7 @@ export class FastAuthSigner<P extends IFastAuthProvider = IFastAuthProvider> {
             account_id: contractId,
             method_name: methodName,
             args_base64: encodedArgs.toString("base64"),
-            sync_checkpoint: "earliest_available",
+            finality: "final",
         });
 
         return JSON.parse(Buffer.from(result.result).toString());


### PR DESCRIPTION
# fix: use finality final instead of sync_checkpoint in rpc view calls

## Changes :hammer_and_wrench:

 ### Relayer / Browser SDK / React SDK

 - Use `finality: "final"` instead of `sync_checkpoint: "earliest_available"` in NEAR RPC view calls.
 - Update the browser signer test to verify the new finality parameter.